### PR TITLE
CommP CID generation (official & correct!)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ commp
 lambda/lambda
 lambda/deployment.zip
 commp_lambda
+commp-cid

--- a/commp-cid.go
+++ b/commp-cid.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"encoding/hex"
+	"fmt"
+	"github.com/ipfs/go-cid"
+	"github.com/multiformats/go-multihash"
+	"os"
+)
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: commp-cid <file>")
+		os.Exit(1)
+	}
+
+	commp, err := hex.DecodeString(os.Args[1])
+	if err != nil {
+		panic(err)
+	}
+
+	mh, err := multihash.Encode(commp, multihash.SHA2_256_TRUNC254_PADDED)
+	if err != nil {
+		panic(err)
+	}
+
+	ccid := cid.NewCidV1(cid.FilCommitmentUnsealed, mh)
+
+	println(ccid.String())
+}

--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,10 @@ require (
 	github.com/filecoin-project/filecoin-ffi v0.0.0-20191219131535-bb699517a590
 	github.com/filecoin-project/go-fil-markets v0.0.0-20200118022459-68964015978c
 	github.com/filecoin-project/go-sectorbuilder v0.0.1
-	github.com/ipfs/go-cid v0.0.5 // indirect
+	github.com/ipfs/go-cid v0.0.5
+	github.com/multiformats/go-multihash v0.0.14-0.20200513002122-6f1ea18f1da5
 )
 
 replace github.com/filecoin-project/filecoin-ffi => ./extern/filecoin-ffi
+
 replace github.com/ipfs/go-cid => ../../ipfs/go-cid

--- a/go.sum
+++ b/go.sum
@@ -369,6 +369,8 @@ github.com/multiformats/go-multihash v0.0.10 h1:lMoNbh2Ssd9PUF74Nz008KGzGPlfeV6w
 github.com/multiformats/go-multihash v0.0.10/go.mod h1:YSLudS+Pi8NHE7o6tb3D8vrpKa63epEDmG8nTduyAew=
 github.com/multiformats/go-multihash v0.0.13 h1:06x+mk/zj1FoMsgNejLpy6QTvJqlSt/BhLEy87zidlc=
 github.com/multiformats/go-multihash v0.0.13/go.mod h1:VdAWLKTwram9oKAatUcLxBNUjdtcVwxObEQBtRfuyjc=
+github.com/multiformats/go-multihash v0.0.14-0.20200513002122-6f1ea18f1da5 h1:uXE5KEUAQE+i1hAfEMbkWsdKrYv+bFJ7pHTH/OME2io=
+github.com/multiformats/go-multihash v0.0.14-0.20200513002122-6f1ea18f1da5/go.mod h1:VdAWLKTwram9oKAatUcLxBNUjdtcVwxObEQBtRfuyjc=
 github.com/multiformats/go-multistream v0.0.1/go.mod h1:fJTiDfXJVmItycydCnNx4+wSzZ5NwG2FEVAI30fiovg=
 github.com/multiformats/go-multistream v0.1.0/go.mod h1:fJTiDfXJVmItycydCnNx4+wSzZ5NwG2FEVAI30fiovg=
 github.com/multiformats/go-varint v0.0.1/go.mod h1:3Ls8CIEsrijN6+B7PbrXRPxHRPuXSrVKRY101jdMZYE=


### PR DESCRIPTION
/cc @hannahhoward @pfac

multicodec table now has new entries for Filecoin, wrapup @ https://github.com/multiformats/multicodec/pull/161#issuecomment-627152617 so the older CommP->CID generation methods should probably be removed (or at least updated) as they are not generating using official codes.

multiformats/go-multihash now has `SHA2_256_TRUNC254_PADDED` @ https://github.com/multiformats/go-multihash/pull/128, although this is not yet released, so you need to grab the HEAD.

ipfs/go-cid has a pending PR for the two codecs, including `FilecoinCommitmentUnsealed` @ https://github.com/ipfs/go-cid/pull/104, so a fork and redirect is needed for now.

In practice, given a commp `faeba569cafd5c144328f8dbb1873c6c0da4ce3a2136a8e2e9b1966bcaa68f0e`:

```
$ ./commp-cid faeba569cafd5c144328f8dbb1873c6c0da4ce3a2136a8e2e9b1966bcaa68f0e
baga6ea4seaqpv25fnhfp2xauimuprw5rq46gydnezy5ccnvi4lu3dftlzkti6dq
```

Then verify:

```
$ node
> mf = require('@ipld/multiformats')
> c = new mf.CID('baga6ea4seaqpv25fnhfp2xauimuprw5rq46gydnezy5ccnvi4lu3dftlzkti6dq')
CID(baga6ea4seaqpv25fnhfp2xauimuprw5rq46gydnezy5ccnvi4lu3dftlzkti6dq)
> Buffer.from(mf.multihash.decode(c.multihash).digest).toString('hex')
'faeba569cafd5c144328f8dbb1873c6c0da4ce3a2136a8e2e9b1966bcaa68f0e'
> c.code.toString(16)
'f101'
> mf.multihash.decode(c.multihash).code.toString(16)
'1012'
```

So we can extract the original commp, the codec for `fil-commitment-unsealed`: `0xf101` and the multihash for `sha2-256-trunc254-padded`: `0x1012`.